### PR TITLE
Fix performance issue in applyMoveTransition

### DIFF
--- a/vue-animated-list.js
+++ b/vue-animated-list.js
@@ -74,6 +74,9 @@
 
     function applyMoveTransition (frags) {
       frags.forEach(function (frag) {
+        frag._newPos = frag.node.getBoundingClientRect()
+      })
+      frags.forEach(function (frag) {
         var node = frag.node
         var oldPos = frag._oldPos
         if (!oldPos) return
@@ -87,9 +90,8 @@
           p.removeChild(node)
           p.insertBefore(node, next)
         }
-        var newPos = node.getBoundingClientRect()
-        var dx = oldPos.left - newPos.left
-        var dy = oldPos.top - newPos.top
+        var dx = oldPos.left - frag._newPos.left
+        var dy = oldPos.top - frag._newPos.top
         if (dx !== 0 || dy !== 0) {
           frag.moved = true
           node.style.transform =


### PR DESCRIPTION
`getBoundingClientRect` causes a DOM reflow when the DOM has been written to between calls (see http://stackoverflow.com/a/37686736/945863). So to avoid this, first call `getBoundingClientRect` on each element in one loop with no intermediate writes to the DOM, then use those results while writing to the DOM in a second loop.

Potential issue with this PR: I'm not sure whether `frags` is outwardly visible. I use the property `_newPos` on each `frag`, which, if it's used by external code, will be stomped.

Before this change, on a list of 23 elements, I was seeing this performance in Chrome:

![screenshot from 2016-09-23 00-10-26](https://cloud.githubusercontent.com/assets/904269/18751560/cf1d646e-8122-11e6-9659-f7021df8bdf5.png)

Notice that each call to `getBoundingClientRect` takes around 30ms. With these changes, it now looks like:

![screenshot from 2016-09-23 00-16-39](https://cloud.githubusercontent.com/assets/904269/18751668/264e104e-8123-11e6-9793-7bd02027ee6e.png)

And the whole call to `applyMoveTransition` is down to 40ms.
